### PR TITLE
Update wss universal agent to 20.5.2

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build whitesource Docker Images with java
-      uses: philips-software/docker-ci-scripts@v2.2.0
+      uses: philips-software/docker-ci-scripts@v2.2.1
       with:
         dockerfile: 20/java 
         image-name: whitesource
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build whitesource Docker Images with node
-      uses: philips-software/docker-ci-scripts@v2.1.0
+      uses: philips-software/docker-ci-scripts@v2.2.1
       with:
         dockerfile: 20/node 
         image-name: whitesource
@@ -49,7 +49,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build whitesource Docker Images with docker
-      uses: philips-software/docker-ci-scripts@v2.1.0
+      uses: philips-software/docker-ci-scripts@v2.2.1
       with:
         dockerfile: 20/docker 
         image-name: whitesource
@@ -68,7 +68,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build whitesource Docker Images with dotnetcore
-      uses: philips-software/docker-ci-scripts@v2.1.0
+      uses: philips-software/docker-ci-scripts@v2.2.1
       with:
         dockerfile: 20/dotnetcore 
         image-name: whitesource

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -11,11 +11,11 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build whitesource Docker Images with java
-      uses: philips-software/docker-ci-scripts@v2.1.0
+      uses: philips-software/docker-ci-scripts@v2.2.0
       with:
         dockerfile: 20/java 
         image-name: whitesource
-        tags: latest 20 20.4 20.4.1 20.4.1.1
+        tags: latest 20 20.5 20.5.2
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -34,7 +34,7 @@ jobs:
       with:
         dockerfile: 20/node 
         image-name: whitesource
-        tags: node 20-node 20.4-node 20.4.1-node 20.4.1.1-node
+        tags: node 20-node 20.5-node 20.5.2-node
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -53,7 +53,7 @@ jobs:
       with:
         dockerfile: 20/docker 
         image-name: whitesource
-        tags: docker 20-docker 20.4-docker 20.4.1-docker 20.4.1.1-docker
+        tags: docker 20-docker 20.5-docker 20.5.2-docker
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -72,7 +72,7 @@ jobs:
       with:
         dockerfile: 20/dotnetcore 
         image-name: whitesource
-        tags: dotnetcore 20-dotnetcore 20-dotnetcore-3 20.4-dotnetcore 20.4-dotnetcore-3.0 20.4.1-dotnetcore 20.4.1-dotnetcore-3.0.101 20.4.1.1-dotnetcore 20.4.1.1-dotnetcore-3.0.101
+        tags: dotnetcore 20-dotnetcore 20-dotnetcore-3 20.5-dotnetcore 20.5-dotnetcore-3.0 20.5.2-dotnetcore 20.5.2-dotnetcore-3.0.101
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'

--- a/20/docker/Dockerfile
+++ b/20/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM philipssoftware/openjdk:11-zulu-docker
 
 MAINTAINER Forest Keepers
 
-ARG wss_latest_release_version=20.4.1.1
+ARG wss_latest_release_version=20.5.2
 ENV WSS_LATEST_RELEASE_VERSION $wss_latest_release_version
 
 USER root

--- a/20/dotnetcore/Dockerfile
+++ b/20/dotnetcore/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.0.101
 
 MAINTAINER Forest Keepers
 
-ARG wss_latest_release_version=20.4.1.1
+ARG wss_latest_release_version=20.5.2
 ENV WSS_LATEST_RELEASE_VERSION $wss_latest_release_version
 
 RUN apt-get update \ 

--- a/20/java/Dockerfile
+++ b/20/java/Dockerfile
@@ -2,7 +2,7 @@ FROM philipssoftware/openjdk:11
 
 MAINTAINER Forest Keepers
 
-ARG wss_latest_release_version=20.4.1.1
+ARG wss_latest_release_version=20.5.2
 ENV WSS_LATEST_RELEASE_VERSION $wss_latest_release_version
 
 USER root

--- a/20/node/Dockerfile
+++ b/20/node/Dockerfile
@@ -2,7 +2,7 @@ FROM philipssoftware/node:10-java
 
 MAINTAINER Forest Keepers
 
-ARG wss_latest_release_version=20.4.1.1
+ARG wss_latest_release_version=20.5.2
 ENV WSS_LATEST_RELEASE_VERSION $wss_latest_release_version
 
 USER root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The version numbers are related to the version of whitesource agent in the image
 - jar name changed into: wss-unified-agent.jar without version
 
 ### Changed
+- Whitesource agent 20.5.2
 - Whitesource agent 20.4.1.1
 - Whitesource agent 20.3.2
 - #6 - Whitesource agent 20.2.2 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The version numbers are related to the version of whitesource agent in the image
 - jar name changed into: wss-unified-agent.jar without version
 
 ### Changed
+- Update docker workflow to version 2.2.1
 - Whitesource agent 20.5.2
 - Whitesource agent 20.4.1.1
 - Whitesource agent 20.3.2

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This contains all the similar tags at the point of creation.
 
 ```
 $ docker run philipssoftware/whitesource:20 cat TAGS
-whitesource whitesource:20 whitesource:20.4 whitesource:20.4.1 whitesource:20.4.1.1
+whitesource whitesource:20 whitesource:20.5 whitesource:20.5.2
 ```
 
 You can use this to pin down a version of the container from an existing development build for production. When using `whitesource:20` for development. This ensures that you've got all security updates in your build. If you want to pin the version of your image down for production, you can use this file inside of the container to look for the most specific tag, the last one.
@@ -63,16 +63,16 @@ You can use this to pin down a version of the container from an existing develop
 ## Simple Tags
 
 ### whitesource
-- `whitesource`, `whitesource:20`, `whitesource:20.4`, `whitesource:20.4.1`, `whitesource:20.4.1.1` [20/java/Dockerfile](20/java/Dockerfile)
+- `whitesource`, `whitesource:20`, `whitesource:20.5`, `whitesource:20.5.2` [20/java/Dockerfile](20/java/Dockerfile)
 
 ### whitesource with node
-- `whitesource:node`, `whitesource:20-node`, `whitesource:20.4-node`, `whitesource:20.4.1-node`, `whitesource:20.4.1.1-node` [20/node/Dockerfile](20/node/Dockerfile)
+- `whitesource:node`, `whitesource:20-node`, `whitesource:20.5-node`, `whitesource:20.5.2-node` [20/node/Dockerfile](20/node/Dockerfile)
 
 ### whitesource with dotnetcore
-- `whitesource:dotnetcore`, `whitesource:20-dotnetcore`, `whitesource:20-dotnetcore-3`, `whitesource:20.4-dotnetcore`, `whitesource:20.4-dotnetcore-3.0`, `whitesource:20.4.1-dotnetcore`, `whitesource:20.4.1-dotnetcore-3.0.101`, `whitesource:20.4.1.1-dotnetcore`, `whitesource:20.4.1.1-dotnetcore-3.0.101` [20/dotnetcore/Dockerfile](20/dotnetcore/Dockerfile)
+- `whitesource:dotnetcore`, `whitesource:20-dotnetcore`, `whitesource:20-dotnetcore-3`, `whitesource:20.5-dotnetcore`, `whitesource:20.5-dotnetcore-3.0`, `whitesource:20.5.2-dotnetcore`, `whitesource:20.5.2-dotnetcore-3.0.101` [20/dotnetcore/Dockerfile](20/dotnetcore/Dockerfile)
 
 ### whitesource with docker
-- `whitesource:docker`, `whitesource:20-docker`, `whitesource:20.4-docker`, `whitesource:20.4.1-docker`, `whitesource:20.4.1.1-docker` [20/docker/Dockerfile](20/docker/Dockerfile)
+- `whitesource:docker`, `whitesource:20-docker`, `whitesource:20.5-docker`, `whitesource:20.5.2-docker` [20/docker/Dockerfile](20/docker/Dockerfile)
 
 
 ## Why


### PR DESCRIPTION
# Update Whitesource Universal Agent

Version: `20.5.2`

## Changes

Whitesource changes: [Release notes White source - 20.5.2](https://whitesource.atlassian.net/wiki/spaces/WD/pages/33718455/WhiteSource+Server+Release+Notes)