### PR TITLE
Update agent to 21.9.1

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         dockerfile: 21/java 
         image-name: whitesource
-        tags: latest 21 21.6 21.6.3
+        tags: latest 21 21.9 21.9.1
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -34,7 +34,7 @@ jobs:
       with:
         dockerfile: 21/node 
         image-name: whitesource
-        tags: node 21-node 21.6-node 21.6.3-node
+        tags: node 21-node 21.9-node 21.9.1-node
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -53,7 +53,7 @@ jobs:
       with:
         dockerfile: 21/docker 
         image-name: whitesource
-        tags: docker 21-docker 21.6-docker 21.6.3-docker
+        tags: docker 21-docker 21.9-docker 21.9.1-docker
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -72,7 +72,7 @@ jobs:
       with:
         dockerfile: 21/dotnetcore 
         image-name: whitesource
-        tags: dotnetcore 21-dotnetcore 21-dotnetcore-3 21.6-dotnetcore 21.6-dotnetcore-3.0 21.6.3-dotnetcore 21.6.3-dotnetcore-3.0.101
+        tags: dotnetcore 21-dotnetcore 21-dotnetcore-3 21.9-dotnetcore 21.9-dotnetcore-3.0 21.9.1-dotnetcore 21.9.1-dotnetcore-3.0.101
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'

--- a/21/docker/Dockerfile
+++ b/21/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM philipssoftware/openjdk:11-zulu-docker
 
 MAINTAINER Forest Keepers
 
-ARG wss_latest_release_version=21.6.3
+ARG wss_latest_release_version=21.9.1
 ENV WSS_LATEST_RELEASE_VERSION $wss_latest_release_version
 
 USER root

--- a/21/dotnetcore/Dockerfile
+++ b/21/dotnetcore/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.0.101
 
 MAINTAINER Forest Keepers
 
-ARG wss_latest_release_version=21.6.3
+ARG wss_latest_release_version=21.9.1
 ENV WSS_LATEST_RELEASE_VERSION $wss_latest_release_version
 
 RUN apt-get update \ 

--- a/21/java/Dockerfile
+++ b/21/java/Dockerfile
@@ -2,7 +2,7 @@ FROM philipssoftware/openjdk:11
 
 MAINTAINER Forest Keepers
 
-ARG wss_latest_release_version=21.6.3
+ARG wss_latest_release_version=21.9.1
 ENV WSS_LATEST_RELEASE_VERSION $wss_latest_release_version
 
 USER root

--- a/21/node/Dockerfile
+++ b/21/node/Dockerfile
@@ -2,7 +2,7 @@ FROM philipssoftware/node:lts-java
 
 MAINTAINER Forest Keepers
 
-ARG wss_latest_release_version=21.6.3
+ARG wss_latest_release_version=21.9.1
 ENV WSS_LATEST_RELEASE_VERSION $wss_latest_release_version
 
 USER root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The version numbers are related to the version of whitesource agent in the image
 - jar name changed into: wss-unified-agent.jar without version
 
 ### Changed
+- Whitesource agent 21.9.1
 - Whitesource agent 21.6.3
 - Whitesource agent 21.4.2
 - Update docker workflow to version 2.2.1

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This contains all the similar tags at the point of creation.
 
 ```
 $ docker run philipssoftware/whitesource:21 cat TAGS
-whitesource whitesource:21 whitesource:21.6 whitesource:21.6.3
+whitesource whitesource:21 whitesource:21.6 whitesource:21.9.1
 ```
 
 You can use this to pin down a version of the container from an existing development build for production. When using `whitesource:21` for development. This ensures that you've got all security updates in your build. If you want to pin the version of your image down for production, you can use this file inside of the container to look for the most specific tag, the last one.
@@ -63,16 +63,16 @@ You can use this to pin down a version of the container from an existing develop
 ## Simple Tags
 
 ### whitesource
-- `whitesource`, `whitesource:21`, `whitesource:21.6`, `whitesource:21.6.3` [21/java/Dockerfile](21/java/Dockerfile)
+- `whitesource`, `whitesource:21`, `whitesource:21.9`, `whitesource:21.9.1` [21/java/Dockerfile](21/java/Dockerfile)
 
 ### whitesource with node
-- `whitesource:node`, `whitesource:21-node`, `whitesource:21.6-node`, `whitesource:21.6.3-node` [21/node/Dockerfile](21/node/Dockerfile)
+- `whitesource:node`, `whitesource:21-node`, `whitesource:21.9-node`, `whitesource:21.9.1-node` [21/node/Dockerfile](21/node/Dockerfile)
 
 ### whitesource with dotnetcore
-- `whitesource:dotnetcore`, `whitesource:21-dotnetcore`, `whitesource:21-dotnetcore-3`, `whitesource:21.6-dotnetcore`, `whitesource:21.6-dotnetcore-3.0`, `whitesource:21.6.3-dotnetcore`, `whitesource:21.6.3-dotnetcore-3.0.101` [21/dotnetcore/Dockerfile](21/dotnetcore/Dockerfile)
+- `whitesource:dotnetcore`, `whitesource:21-dotnetcore`, `whitesource:21-dotnetcore-3`, `whitesource:21.9-dotnetcore`, `whitesource:21.9-dotnetcore-3.0`, `whitesource:21.9.1-dotnetcore`, `whitesource:21.9.1-dotnetcore-3.0.101` [21/dotnetcore/Dockerfile](21/dotnetcore/Dockerfile)
 
 ### whitesource with docker
-- `whitesource:docker`, `whitesource:21-docker`, `whitesource:21.6-docker`, `whitesource:21.6.3-docker` [21/docker/Dockerfile](21/docker/Dockerfile)
+- `whitesource:docker`, `whitesource:21-docker`, `whitesource:21.9-docker`, `whitesource:21.9.1-docker` [21/docker/Dockerfile](21/docker/Dockerfile)
 
 
 ## Why


### PR DESCRIPTION
Whitesource agent has released a new version on 2021-10-17.

Version: [21.9.1](https://whitesource.atlassian.net/wiki/spaces/WD/pages/1140852201/Getting+Started+with+the+Unified+Agent#Downloading-the-Unified-Agent)

[Release notes](https://whitesource.atlassian.net/wiki/spaces/WD/pages/33718455/WhiteSource+Server+Release+Notes#Version-21.9.1-(17-October-2021))


